### PR TITLE
Add skeleton for Weather Forecast Accuracy Tracker

### DIFF
--- a/forecast_accuracy/analysis.py
+++ b/forecast_accuracy/analysis.py
@@ -1,0 +1,28 @@
+from typing import List
+import pandas as pd
+import numpy as np
+
+
+def compute_mae(actual: pd.Series, forecast: pd.Series) -> float:
+    """Mean Absolute Error."""
+    return np.mean(np.abs(actual - forecast))
+
+
+def compute_rmse(actual: pd.Series, forecast: pd.Series) -> float:
+    """Root Mean Squared Error."""
+    return np.sqrt(np.mean((actual - forecast) ** 2))
+
+
+METRIC_FUNCTIONS = {
+    "MAE": compute_mae,
+    "RMSE": compute_rmse,
+}
+
+
+def evaluate_metrics(actual: pd.Series, forecast: pd.Series, metrics: List[str]):
+    results = {}
+    for m in metrics:
+        func = METRIC_FUNCTIONS.get(m)
+        if func:
+            results[m] = func(actual, forecast)
+    return results

--- a/forecast_accuracy/data_fetcher.py
+++ b/forecast_accuracy/data_fetcher.py
@@ -1,0 +1,31 @@
+import os
+import requests
+from typing import Dict
+
+OPENWEATHER_API_URL = "https://api.openweathermap.org/data/2.5"
+
+
+def fetch_forecast(city: str, api_key: str = None) -> Dict:
+    """Fetch 7 day forecast for a given city using OpenWeatherMap."""
+    api_key = api_key or os.getenv("OPENWEATHER_API_KEY")
+    if not api_key:
+        raise ValueError("OPENWEATHER_API_KEY not provided")
+
+    url = f"{OPENWEATHER_API_URL}/forecast"  # 5 day/3 hour forecast
+    params = {"q": city, "appid": api_key, "units": "metric"}
+    response = requests.get(url, params=params, timeout=10)
+    response.raise_for_status()
+    return response.json()
+
+
+def fetch_current(city: str, api_key: str = None) -> Dict:
+    """Fetch current weather data for a city."""
+    api_key = api_key or os.getenv("OPENWEATHER_API_KEY")
+    if not api_key:
+        raise ValueError("OPENWEATHER_API_KEY not provided")
+
+    url = f"{OPENWEATHER_API_URL}/weather"
+    params = {"q": city, "appid": api_key, "units": "metric"}
+    response = requests.get(url, params=params, timeout=10)
+    response.raise_for_status()
+    return response.json()

--- a/forecast_accuracy/storage.py
+++ b/forecast_accuracy/storage.py
@@ -1,0 +1,28 @@
+import csv
+from pathlib import Path
+from typing import List, Dict, Iterable
+
+
+DATA_DIR = Path("data")
+DATA_DIR.mkdir(exist_ok=True)
+
+
+def save_records(filename: str, records: Iterable[Dict]) -> None:
+    """Save a list of dictionaries to CSV."""
+    path = DATA_DIR / filename
+    if not records:
+        return
+    with path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=records[0].keys())
+        writer.writeheader()
+        writer.writerows(records)
+
+
+def load_records(filename: str) -> List[Dict]:
+    """Load records from a CSV file."""
+    path = DATA_DIR / filename
+    if not path.exists():
+        return []
+    with path.open("r", newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        return list(reader)

--- a/forecast_accuracy/visualization.py
+++ b/forecast_accuracy/visualization.py
@@ -1,0 +1,20 @@
+import pandas as pd
+import matplotlib.pyplot as plt
+from pathlib import Path
+
+PLOT_DIR = Path("plots")
+PLOT_DIR.mkdir(exist_ok=True)
+
+
+def plot_forecast_vs_actual(df: pd.DataFrame, date_col: str, actual_col: str, forecast_col: str, city: str) -> Path:
+    fig, ax = plt.subplots()
+    df.plot(x=date_col, y=actual_col, ax=ax, label="Actual")
+    df.plot(x=date_col, y=forecast_col, ax=ax, label="Forecast")
+    ax.set_title(f"Forecast vs Actual - {city}")
+    ax.set_xlabel("Date")
+    ax.set_ylabel("Value")
+    ax.legend()
+    path = PLOT_DIR / f"forecast_vs_actual_{city}.png"
+    fig.savefig(path)
+    plt.close(fig)
+    return path

--- a/readme.md
+++ b/readme.md
@@ -27,3 +27,20 @@ Zbrati in strukturirati vremenske napovedi ter meritve. Oceniti točnost napoved
 - Pandas, NumPy: analiza
 - Matplotlib, Plotly: vizualizacije
 - APIs: vremenski podatki (npr. OpenWeatherMap, ARSO, Meteostat, ipd.)
+
+## Navodila za zagon
+
+1. Namesti odvisnosti:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Nastavi okoljsko spremenljivko `OPENWEATHER_API_KEY` s svojim API ključem.
+3. Zaženi skripto:
+   ```bash
+   python run_analysis.py
+   ```
+
+Skripta pridobi napovedi in trenutne podatke za Koper, Ljubljano in Maribor,
+shrani rezultate v mapo `data/`, izračuna osnovne metrike (MAE, RMSE) ter
+ustvari graf napovedi in dejanskih meritev v mapi `plots/`.
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+pandas
+numpy
+matplotlib
+requests

--- a/run_analysis.py
+++ b/run_analysis.py
@@ -1,0 +1,36 @@
+import pandas as pd
+from forecast_accuracy import data_fetcher, storage, analysis, visualization
+
+CITIES = ["Koper", "Ljubljana", "Maribor"]
+
+
+def main():
+    for city in CITIES:
+        print(f"Fetching data for {city}...")
+        forecast_data = data_fetcher.fetch_forecast(city)
+        current_data = data_fetcher.fetch_current(city)
+
+        storage.save_records(f"forecast_{city}.csv", forecast_data.get("list", []))
+        storage.save_records(f"current_{city}.csv", [current_data])
+
+        # Example analysis: this expects that forecast_data has 'main' field
+        forecast_temps = [item["main"]["temp"] for item in forecast_data.get("list", [])]
+        actual_temp = current_data["main"]["temp"] if current_data else None
+        if actual_temp is None or not forecast_temps:
+            print(f"No data for {city}")
+            continue
+
+        df = pd.DataFrame({
+            "forecast": forecast_temps,
+            "actual": [actual_temp] * len(forecast_temps)
+        })
+        mae = analysis.compute_mae(df["actual"], df["forecast"])
+        rmse = analysis.compute_rmse(df["actual"], df["forecast"])
+        print(f"{city} - MAE: {mae:.2f}, RMSE: {rmse:.2f}")
+
+        df["timestamp"] = [item["dt_txt"] for item in forecast_data.get("list", [])]
+        visualization.plot_forecast_vs_actual(df, "timestamp", "actual", "forecast", city)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement basic modules for fetching weather data, storing data, computing metrics, and plotting
- add runnable script `run_analysis.py`
- document usage steps in `readme.md`
- specify Python dependencies

## Testing
- `python -m py_compile forecast_accuracy/*.py run_analysis.py`

------
https://chatgpt.com/codex/tasks/task_e_68415f40bdd083288d32d1f2bf7464b0